### PR TITLE
Correct typo in Technical Capstone section

### DIFF
--- a/capstone/fe_engineering/index.html
+++ b/capstone/fe_engineering/index.html
@@ -75,7 +75,7 @@ subheading: Front End Engineering
     {% include pd-gu-capstone-instructions.html %}
 
     <h3>Technical Capstone</h3>
-    <p>At Turing, you will have to code every single day to stay on top of the workload and build muscle memory for everything you've learned. This 7 days of the mod 0 capstone is desgined to get you into that essential routine before the first day of class.</p>
+    <p>At Turing, you will have to code every single day to stay on top of the workload and build muscle memory for everything you've learned. This 7 days of the mod 0 capstone is designed to get you into that essential routine before the first day of class.</p>
     <p>Even if you plan to spend 14 days on this 7-day mod 0 capstone, you should break up the work so that you are doing work and coding every day, even if it is only a little.</p>
 
     <article>


### PR DESCRIPTION
Correct typo on the work 'design' in the Technical Capstone paragraph of FE Capstone page