### PR TITLE
Fix broken link for calendaring image

### DIFF
--- a/shared/calendaring.md
+++ b/shared/calendaring.md
@@ -66,7 +66,7 @@ Mod 0 is short and fast! That may lead us to believe we don't have much time to 
 
 Here is an example of what your calendar might look like if you are a student in Mod 0. Notice that there is still some empty space on the calendar. That's important too! We still need some breathing room, so that we can adjust along the way.
 
-![Calendar screenshot for a Mod 0 student](assets/calendar-example.png)
+![Calendar screenshot for a Mod 0 student](../prework/assets/calendar-example.png)
 
 ## Mod 1
 


### PR DESCRIPTION
### Changes
- Change the filepath for the broken image in the calendaring lesson 
   - The image was moved to the `prework/assets` folder in the `fast-trak-prework` branch but the image source was not updated

### Sreenshots of UI 
#### Issue
![Screenshot 2023-10-26 at 8 54 29 AM](https://github.com/turingschool/mod-0-curriculum/assets/121131581/0fe10265-fe74-44f4-a677-bb01dab8667b)
#### Solution 
![Screen Shot 2023-10-26 at 12 38 04 PM](https://github.com/turingschool/mod-0-curriculum/assets/121131581/4a359a77-2765-4710-8e02-e4db7cb28883)
